### PR TITLE
fix(atr): accept all current ATR agent_source.type + severity values

### DIFF
--- a/app/features/rule/rule_format/available_format/atr_format.py
+++ b/app/features/rule/rule_format/available_format/atr_format.py
@@ -38,11 +38,26 @@ _ATR_CATEGORIES = frozenset(
     }
 )
 
-# Valid ATR severities. Same shape as Sigma's severity enum.
-_ATR_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
+# Valid ATR severities, per the ATR schema severity enum.
+_ATR_SEVERITIES = frozenset({"critical", "high", "medium", "low", "informational"})
 
-# Valid agent_source.type values per ATR's evolving schema (additive).
-_ATR_AGENT_SOURCE_TYPES = frozenset({"llm_io", "tool_call", "skill_manifest", "agent_loop"})
+# Valid agent_source.type values, per the ATR schema agent_source.type enum
+# (spec/atr-schema.yaml). ATR's schema is additive; this mirrors the current set.
+_ATR_AGENT_SOURCE_TYPES = frozenset(
+    {
+        "llm_io",           # LLM input/output (prompts and completions)
+        "tool_call",        # Function/tool call requests
+        "mcp_exchange",     # MCP protocol messages
+        "agent_behavior",   # Agent behavioral metrics and patterns
+        "multi_agent_comm", # Inter-agent communication
+        "context_window",   # Context window contents
+        "memory_access",    # Agent memory read/write operations
+        "skill_lifecycle",  # MCP skill registration, update, removal events
+        "skill_permission", # Skill permission requests and boundary checks
+        "skill_chain",      # Multi-skill invocation sequences
+        "agent_trace",      # Agent execution trace (OpenInference/OTel GenAI spans)
+    }
+)
 
 
 class ATRRule(RuleType):
@@ -57,7 +72,7 @@ class ATRRule(RuleType):
     model-security, privilege-escalation.
 
     Upstream: https://github.com/Agent-Threat-Rule/agent-threat-rules
-    npm:      `agent-threat-rules` (MIT, currently v3.5.0 / 652 rules).
+    npm:      `agent-threat-rules` (MIT, currently v3.5.6 / 713 rules).
     """
 
     @property

--- a/tests/rules/test_atr_format.py
+++ b/tests/rules/test_atr_format.py
@@ -235,6 +235,16 @@ def test_validate_accepts_canonical_atr_rule(atr: ATRRule) -> None:
     assert result.normalized_content == _VALID_ATR_RULE
 
 
+def test_validate_accepts_current_agent_source_types(atr: ATRRule) -> None:
+    # These agent_source.type values are all in the current ATR schema enum.
+    # mcp_exchange in particular backs the largest share of upstream rules,
+    # so rejecting it here silently dropped most of the ruleset on import.
+    for source_type in ("mcp_exchange", "multi_agent_comm", "agent_trace", "memory_access"):
+        rule = _VALID_ATR_RULE.replace("type: llm_io", f"type: {source_type}")
+        result = atr.validate(rule)
+        assert result.ok is True, (source_type, result.errors)
+
+
 def test_validate_rejects_bad_id(atr: ATRRule) -> None:
     result = atr.validate(_INVALID_ATR_BAD_ID)
     assert result.ok is False


### PR DESCRIPTION
## Problem

The ATR importer's `_ATR_AGENT_SOURCE_TYPES` allow-list only contained four values:

```python
{"llm_io", "tool_call", "skill_manifest", "agent_loop"}
```

Two of those (`skill_manifest`, `agent_loop`) are **not** in the current ATR schema, and the list is missing most of the values that upstream rules actually use. Against the current `agent-threat-rules` release, roughly 370 of 713 rules carry an `agent_source.type` outside this set — most notably `mcp_exchange` (~292 rules) — so they fail semantic validation and are silently dropped on import.

`_ATR_SEVERITIES` was also missing `informational`, which is part of the ATR severity enum.

## Fix

- `_ATR_AGENT_SOURCE_TYPES` now mirrors the current ATR schema `agent_source.type` enum (`llm_io`, `tool_call`, `mcp_exchange`, `agent_behavior`, `multi_agent_comm`, `context_window`, `memory_access`, `skill_lifecycle`, `skill_permission`, `skill_chain`, `agent_trace`).
- `_ATR_SEVERITIES` adds `informational`.
- Refreshed the version note in the docstring (`v3.5.0 / 652` → `v3.5.6 / 713`).

## Tests

Added `test_validate_accepts_current_agent_source_types` covering `mcp_exchange`, `multi_agent_comm`, `agent_trace`, `memory_access`. Full suite runs clean locally: **283 passed, 3 skipped**.
