### PR TITLE
added support kusto kql rule format plus basic tests

### DIFF
--- a/app/features/rule/rule_format/available_format/kql_format.py
+++ b/app/features/rule/rule_format/available_format/kql_format.py
@@ -1,0 +1,249 @@
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+from app.features.rule.rule_core import get_rule
+from app.features.rule.rule_format.abstract_rule_type.rule_type_abstract import RuleType, ValidationResult
+from app.core.utils.utils import detect_cve
+
+
+###############################################################################
+#   KQL class                                                                #
+#                                                                             #
+#   KQL (Kusto Query Language) detection/hunting rules are stored as plain   #
+#   .kql files — one query per file, the same convention used by the public  #
+#   Azure-Sentinel / Kusto-Query-Language GitHub repos. There is no wrapper  #
+#   schema (unlike Sigma/ATR's YAML), so metadata is optionally read from a  #
+#   leading `// Key: Value` comment header and otherwise defaulted/inferred  #
+#   from the filename.                                                       #
+###############################################################################
+
+
+# Optional `// Key: Value` header lines at the top of the file.
+_HEADER_LINE_RE = re.compile(r'^//\s*([A-Za-z][\w \-]*?)\s*:\s*(.+)$')
+
+# Kusto control/management commands (`.show`, `.create table`, `.drop`, ...)
+# are cluster administration, not a detection query, and must be rejected.
+_MGMT_COMMAND_RE = re.compile(r'^\s*\.\w+')
+
+_BRACKET_PAIRS = {'(': ')', '[': ']', '{': '}'}
+_BRACKET_CLOSERS = {v: k for k, v in _BRACKET_PAIRS.items()}
+
+
+def _strip_comments(content: str) -> str:
+    """Return the content with blank and `//` comment lines removed."""
+    body_lines = [
+        line for line in content.splitlines()
+        if line.strip() and not line.strip().startswith('//')
+    ]
+    return "\n".join(body_lines).strip()
+
+
+def _parse_header(content: str) -> Dict[str, str]:
+    """Parse the leading contiguous block of `// Key: Value` comment lines."""
+    meta: Dict[str, str] = {}
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith('//'):
+            break
+        match = _HEADER_LINE_RE.match(stripped)
+        if match:
+            key = match.group(1).strip().lower().replace(' ', '_')
+            meta[key] = match.group(2).strip()
+    return meta
+
+
+def _title_from_filename(filepath: Optional[str]) -> Optional[str]:
+    if not filepath:
+        return None
+    name = os.path.splitext(os.path.basename(filepath))[0]
+    name = re.sub(r'[-_]+', ' ', name).strip()
+    return name.title() if name else None
+
+
+class KQLRule(RuleType):
+    """
+    Concrete implementation of RuleType for KQL (Kusto Query Language) rules.
+    """
+
+    @property
+    def format(self) -> str:
+        return "kql"
+
+    def get_class(self) -> str:
+        return "KQLRule"
+
+    # ---------------------#
+    #   Abstract section   #
+    # ---------------------#
+
+    def validate(self, content: str, **kwargs) -> ValidationResult:
+        """
+        Heuristically validate a raw KQL query.
+
+        There is no Python Kusto engine available to compile/execute against,
+        so validation is syntactic: strips comments, rejects cluster
+        management commands, and checks for balanced brackets/quotes and a
+        sane first token (a query cannot open with a pipe).
+        """
+        if not content or not content.strip():
+            return ValidationResult(ok=False, errors=["Rule content is empty."], normalized_content=content)
+
+        body = _strip_comments(content)
+        if not body:
+            return ValidationResult(
+                ok=False,
+                errors=["No query body found (file only contains comments)."],
+                normalized_content=content,
+            )
+
+        errors: List[str] = []
+        warnings: List[str] = []
+
+        if _MGMT_COMMAND_RE.match(body):
+            errors.append("Query looks like a Kusto control command (starts with '.'), not a detection query.")
+
+        if body.startswith('|'):
+            errors.append("Query cannot start with a pipe '|' — expected a table name, 'let', or 'union' first.")
+
+        # Balanced brackets, aware of (single/double) quoted strings.
+        stack: List[str] = []
+        in_string = False
+        string_char = ""
+        escaped = False
+        for ch in body:
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif ch == '\\':
+                    escaped = True
+                elif ch == string_char:
+                    in_string = False
+                continue
+            if ch in ('"', "'"):
+                in_string = True
+                string_char = ch
+                continue
+            if ch in _BRACKET_PAIRS:
+                stack.append(ch)
+            elif ch in _BRACKET_CLOSERS:
+                if not stack or stack[-1] != _BRACKET_CLOSERS[ch]:
+                    errors.append(f"Unbalanced '{ch}' in query.")
+                    break
+                stack.pop()
+        else:
+            if stack:
+                errors.append(f"Unclosed '{stack[-1]}' in query.")
+        if in_string:
+            errors.append("Unterminated string literal in query.")
+
+        if '|' not in body and not re.search(r'\blet\b', body):
+            warnings.append("Query has no pipe ('|') operators — it looks like a bare table reference.")
+
+        ok = len(errors) == 0
+        return ValidationResult(ok=ok, errors=errors, warnings=warnings, normalized_content=content)
+
+    def parse_metadata(self, content: str, info: Dict, validation_result: ValidationResult) -> Dict[str, Any]:
+        """Extract metadata from an optional leading comment header, falling back to the filename/defaults."""
+        info = info or {}
+        fallback_title = _title_from_filename(info.get("filepath")) or "Untitled KQL Query"
+
+        try:
+            meta = _parse_header(content)
+
+            title = meta.get('title') or meta.get('name') or fallback_title
+            description = meta.get('description') or "No description provided"
+            _, cve = detect_cve(description)
+
+            tags: List[str] = []
+            for key in ('tags', 'mitre', 'mitre_att&ck', 'attack'):
+                if meta.get(key):
+                    tags.extend(t.strip() for t in meta[key].split(',') if t.strip())
+
+            return {
+                "format": "kql",
+                "title": title,
+                "license": meta.get("license") or info.get("license", "unknown"),
+                "description": description,
+                "source": meta.get("source") or info.get("repo_url", "Unknown"),
+                "version": meta.get("version", "1.0"),
+                "original_uuid": meta.get("id") or meta.get("uuid") or "Unknown",
+                "author": meta.get("author") or info.get("author", "Unknown"),
+                "to_string": content,
+                "cve_id": cve,
+                "severity": meta.get("severity", "unknown"),
+                "tags": tags,
+            }
+        except Exception as e:
+            return {
+                "format": "kql",
+                "title": f"{fallback_title} (Metadata Error)",
+                "license": info.get("license", "unknown"),
+                "description": f"Error parsing metadata: {e}",
+                "version": "N/A",
+                "source": info.get("repo_url", "Unknown"),
+                "original_uuid": "Unknown",
+                "author": info.get("author", "Unknown"),
+                "cve_id": [],
+                "to_string": content,
+            }
+
+    def get_rule_files(self, file: str) -> bool:
+        return file.endswith('.kql')
+
+    def extract_rules_from_file(self, filepath: str) -> List[str]:
+        """
+        Extract the KQL query from a file.
+
+        The public KQL rule repos (Azure-Sentinel, Kusto-Query-Language) use
+        one query per file, so the whole file — minus a check that it isn't
+        comment-only — is the rule.
+        """
+        try:
+            with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
+                content = f.read()
+        except Exception:
+            return []
+
+        if not _strip_comments(content):
+            return []
+
+        return [content.strip()]
+
+    def get_rule_files_update(self, repo_dir: str) -> List[str]:
+        """Retrieve all KQL rule files from a repository."""
+        kql_files = []
+        for root, dirs, files in os.walk(repo_dir):
+            dirs[:] = [d for d in dirs if not d.startswith('.') and not d.startswith('_')]
+            for file in files:
+                if file.startswith('.') or file.startswith('_'):
+                    continue
+                if self.get_rule_files(file):
+                    kql_files.append(os.path.join(root, file))
+        return kql_files
+
+    def find_rule_in_repo(self, repo_dir: str, rule_id: int) -> tuple[str, bool]:
+        """
+        Search for a KQL rule inside a locally cloned repo, matching by the
+        stable id/uuid from the header (if present) or by title otherwise.
+        """
+        rule = get_rule(rule_id)
+        if not rule:
+            return "No rule found in the database.", False
+
+        kql_files = self.get_rule_files_update(repo_dir)
+
+        for filepath in kql_files:
+            for r in self.extract_rules_from_file(filepath):
+                meta = _parse_header(r)
+                candidate_uuid = meta.get('id') or meta.get('uuid')
+                if candidate_uuid and rule.original_uuid and candidate_uuid == rule.original_uuid:
+                    return r, True
+
+                candidate_title = meta.get('title') or meta.get('name') or _title_from_filename(filepath)
+                if candidate_title and candidate_title == rule.title:
+                    return r, True
+
+        return f"KQL rule '{rule.title}' not found inside local repo.", False

--- a/tests/rules/test_kql_format.py
+++ b/tests/rules/test_kql_format.py
@@ -1,0 +1,229 @@
+"""
+Unit tests for the KQL (Kusto Query Language) format adapter.
+
+The adapter mirrors the contract documented in
+`app/features/rule/rule_format/abstract_rule_type/rule_type_abstract.py`
+and is structured to match the existing `atr_format` tests for consistency.
+
+KQL rules ship as raw .kql files (one query per file, no YAML wrapper), so
+metadata comes from an optional leading `// Key: Value` comment header and
+otherwise falls back to the filename / defaults.
+"""
+from __future__ import annotations
+
+import json
+from textwrap import dedent
+
+import pytest
+
+from app.features.rule.rule_format.abstract_rule_type.rule_type_abstract import ValidationResult
+from app.features.rule.rule_format.available_format.kql_format import KQLRule
+
+
+# -------------------------------------------------------------------------
+#                           Sample rule fixtures
+# -------------------------------------------------------------------------
+
+_VALID_KQL_RULE = dedent(
+    """\
+    // Title: Suspicious sign-in spike
+    // Description: Detects a spike in failed sign-ins for a single user
+    // Author: Contoso SOC
+    // License: MIT
+    // Severity: Medium
+    // Tags: initial-access, credential-access
+    SigninLogs
+    | where ResultType != 0
+    | summarize FailedCount = count() by UserPrincipalName
+    | where FailedCount > 5
+    """
+)
+
+_VALID_KQL_RULE_WITH_CVE = dedent(
+    """\
+    // Title: SmartScreen bypass exploitation
+    // Description: Detects exploitation attempts for CVE-2024-21412 in SmartScreen bypass campaigns
+    DeviceProcessEvents
+    | where ProcessCommandLine has ".url"
+    """
+)
+
+_VALID_KQL_NO_HEADER = dedent(
+    """\
+    SecurityEvent
+    | where EventID == 4625
+    """
+)
+
+_BARE_TABLE_REFERENCE = "SecurityEvent"
+
+_INVALID_STARTS_WITH_PIPE = "| where 1 == 1"
+
+_INVALID_UNBALANCED_BRACKET = dedent(
+    """\
+    SigninLogs
+    | where (ResultType != 0
+    """
+)
+
+_INVALID_MGMT_COMMAND = ".show tables"
+
+_INVALID_COMMENT_ONLY = dedent(
+    """\
+    // Title: Nothing here
+    // just comments, no query body
+    """
+)
+
+
+# -------------------------------------------------------------------------
+#                                Tests
+# -------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def kql() -> KQLRule:
+    return KQLRule()
+
+
+def test_format_identifier(kql: KQLRule) -> None:
+    assert kql.format == "kql"
+    assert kql.get_class() == "KQLRule"
+
+
+# ---- validate() ------------------------------------------------------------
+
+
+def test_validate_accepts_canonical_kql_rule(kql: KQLRule) -> None:
+    result = kql.validate(_VALID_KQL_RULE)
+    assert isinstance(result, ValidationResult)
+    assert result.ok is True, result.errors
+    assert result.errors == []
+    assert result.normalized_content == _VALID_KQL_RULE
+
+
+def test_validate_accepts_rule_without_header(kql: KQLRule) -> None:
+    result = kql.validate(_VALID_KQL_NO_HEADER)
+    assert result.ok is True, result.errors
+
+
+def test_validate_warns_on_bare_table_reference(kql: KQLRule) -> None:
+    result = kql.validate(_BARE_TABLE_REFERENCE)
+    assert result.ok is True
+    assert any("pipe" in w for w in result.warnings)
+
+
+def test_validate_rejects_empty_content(kql: KQLRule) -> None:
+    result = kql.validate("")
+    assert result.ok is False
+    assert any("empty" in e.lower() for e in result.errors)
+
+
+def test_validate_rejects_comment_only_content(kql: KQLRule) -> None:
+    result = kql.validate(_INVALID_COMMENT_ONLY)
+    assert result.ok is False
+    assert any("comments" in e.lower() for e in result.errors)
+
+
+def test_validate_rejects_query_starting_with_pipe(kql: KQLRule) -> None:
+    result = kql.validate(_INVALID_STARTS_WITH_PIPE)
+    assert result.ok is False
+    assert any("pipe" in e.lower() for e in result.errors)
+
+
+def test_validate_rejects_unbalanced_bracket(kql: KQLRule) -> None:
+    result = kql.validate(_INVALID_UNBALANCED_BRACKET)
+    assert result.ok is False
+    assert any("unclosed" in e.lower() for e in result.errors)
+
+
+def test_validate_rejects_management_command(kql: KQLRule) -> None:
+    result = kql.validate(_INVALID_MGMT_COMMAND)
+    assert result.ok is False
+    assert any("control command" in e.lower() for e in result.errors)
+
+
+# ---- parse_metadata() ----------------------------------------------------
+
+
+def test_parse_metadata_reads_header_fields(kql: KQLRule) -> None:
+    validation_result = kql.validate(_VALID_KQL_RULE)
+    meta = kql.parse_metadata(_VALID_KQL_RULE, {}, validation_result)
+    assert meta["format"] == "kql"
+    assert meta["title"] == "Suspicious sign-in spike"
+    assert meta["description"] == "Detects a spike in failed sign-ins for a single user"
+    assert meta["author"] == "Contoso SOC"
+    assert meta["license"] == "MIT"
+    assert meta["severity"] == "Medium"
+    assert meta["tags"] == ["initial-access", "credential-access"]
+    assert meta["to_string"] == _VALID_KQL_RULE
+
+
+def test_parse_metadata_falls_back_to_filename_title(kql: KQLRule) -> None:
+    validation_result = kql.validate(_VALID_KQL_NO_HEADER)
+    meta = kql.parse_metadata(
+        _VALID_KQL_NO_HEADER, {"filepath": "failed-logon-burst.kql"}, validation_result
+    )
+    assert meta["title"] == "Failed Logon Burst"
+    assert meta["description"] == "No description provided"
+
+
+def test_parse_metadata_falls_back_to_default_title_without_filepath(kql: KQLRule) -> None:
+    validation_result = kql.validate(_VALID_KQL_NO_HEADER)
+    meta = kql.parse_metadata(_VALID_KQL_NO_HEADER, {}, validation_result)
+    assert meta["title"] == "Untitled KQL Query"
+
+
+def test_parse_metadata_detects_cve_in_description(kql: KQLRule) -> None:
+    validation_result = kql.validate(_VALID_KQL_RULE_WITH_CVE)
+    meta = kql.parse_metadata(_VALID_KQL_RULE_WITH_CVE, {}, validation_result)
+    cves = json.loads(meta["cve_id"])
+    assert "CVE-2024-21412" in cves
+
+
+def test_parse_metadata_uses_info_defaults(kql: KQLRule) -> None:
+    validation_result = kql.validate(_VALID_KQL_NO_HEADER)
+    meta = kql.parse_metadata(
+        _VALID_KQL_NO_HEADER,
+        {"license": "Apache-2.0", "author": "Jane Doe", "repo_url": "https://example/repo"},
+        validation_result,
+    )
+    assert meta["license"] == "Apache-2.0"
+    assert meta["author"] == "Jane Doe"
+    assert meta["source"] == "https://example/repo"
+
+
+# ---- get_rule_files() ----------------------------------------------------
+
+
+def test_get_rule_files_accepts_kql_extension(kql: KQLRule) -> None:
+    assert kql.get_rule_files("rules/foo.kql") is True
+
+
+def test_get_rule_files_rejects_other_extensions(kql: KQLRule) -> None:
+    assert kql.get_rule_files("rules/foo.txt") is False
+    assert kql.get_rule_files("rules/foo.yaml") is False
+
+
+# ---- extract_rules_from_file() -------------------------------------------
+
+
+def test_extract_rules_from_single_rule_file(kql: KQLRule, tmp_path) -> None:
+    p = tmp_path / "rule.kql"
+    p.write_text(_VALID_KQL_RULE, encoding="utf-8")
+    rules = kql.extract_rules_from_file(str(p))
+    assert len(rules) == 1
+    assert rules[0] == _VALID_KQL_RULE.strip()
+
+
+def test_extract_rules_from_comment_only_file_is_empty(kql: KQLRule, tmp_path) -> None:
+    p = tmp_path / "empty.kql"
+    p.write_text(_INVALID_COMMENT_ONLY, encoding="utf-8")
+    rules = kql.extract_rules_from_file(str(p))
+    assert rules == []
+
+
+def test_extract_rules_from_missing_file_is_empty(kql: KQLRule, tmp_path) -> None:
+    missing = tmp_path / "does-not-exist.kql"
+    rules = kql.extract_rules_from_file(str(missing))
+    assert rules == []


### PR DESCRIPTION
I added support for rules in kql (kusto) format which is used by various MS security tools. It does basic validation and meta data extraction on a best effort basis. Some unit tests are also included.
I didn't change any UI related files, so it has to be activated by adding the 'kql' format in the Admin section via the 'New Format' button.
This contribution was co-authored by my buddy Claude.